### PR TITLE
Fix typo in docs (acccess -> access)

### DIFF
--- a/docs/resources/bucket_key.md
+++ b/docs/resources/bucket_key.md
@@ -21,7 +21,7 @@ resource "garage_bucket" "bucket" {}
 
 resource "garage_bucket_key" "bucket_key_read-only" {
   bucket_id     = garage_bucket.bucket.id
-  access_key_id = garage_key.key.acccess_key_id
+  access_key_id = garage_key.key.access_key_id
   read          = true
 }
 ```

--- a/examples/resources/garage_bucket_key/resource.tf
+++ b/examples/resources/garage_bucket_key/resource.tf
@@ -6,6 +6,6 @@ resource "garage_bucket" "bucket" {}
 
 resource "garage_bucket_key" "bucket_key_read-only" {
   bucket_id     = garage_bucket.bucket.id
-  access_key_id = garage_key.key.acccess_key_id
+  access_key_id = garage_key.key.access_key_id
   read          = true
 }


### PR DESCRIPTION
Fixes a minor typo in examples.